### PR TITLE
chore: specify files to be included on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "homepage": "https://github.com/paypal/Payouts-NodeJS-SDK#readme",
   "author": "dl-paypal-payouts-sdk@paypal.com (https://developer.paypal.com/)",
   "main": "index",
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
When I install the `@paypal/payouts-sdk` from npm, it includes files that are not necessary for client's use which takes up space, such as `specs`, `samples`, and `homepage.jpg`. By specifying files in package.json, it removes unnecessary files when other people installs the sdk.