### PR TITLE
Release v1.1.0 - restrict files published to npm package, add samples for failure response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+### 1.1.0 (2021-02-19)
+
+*  Specify files to be included in package, removes samples, spec and unwanted files from package ([21527b3](https://github.com/paypal/Payouts-NodeJS-SDK/pull/4/commits/21527b323888037c68fc976c6d988c843f819b9f))
+*  Add samples for handling api failure ([8b2f2b7](https://github.com/paypal/Payouts-NodeJS-SDK/commit/8b2f2b70ac60f18bde038a46c11408547d671e30))

--- a/README.md
+++ b/README.md
@@ -137,14 +137,16 @@ let createPayouts  = async function(){
         console.log(`Response: ${JSON.stringify(response)}`);
         // If call returns body in response, you can get the deserialized version from the result attribute of the response.
         console.log(`Payouts Create Response: ${JSON.stringify(response.result)}`);
-    catch {
+    catch (e) {
       if (e.statusCode) {
+        //Handle server side/API failure response
         console.log("Status code: ", e.statusCode);
         // Parse failure response to get the reason for failure
         const error = JSON.parse(e.message)
         console.log("Failure response: ", error)
         console.log("Headers: ", e.headers)
       } else {
+        //Hanlde client side failure
         console.log(e)
       }
     }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let requestBody = {
       "email_subject": "This is a test transaction from SDK"
     },
     "items": [{
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -45,7 +45,7 @@ let requestBody = {
       "receiver": "payout-sdk-1@paypal.com",
       "sender_item_id": "Test_txn_1"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -53,7 +53,7 @@ let requestBody = {
       "receiver": "payout-sdk-2@paypal.com",
       "sender_item_id": "Test_txn_2"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -61,7 +61,7 @@ let requestBody = {
       "receiver": "payout-sdk-3@paypal.com",
       "sender_item_id": "Test_txn_3"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -69,7 +69,7 @@ let requestBody = {
       "receiver": "payout-sdk-4@paypal.com",
       "sender_item_id": "Test_txn_4"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -111,11 +111,11 @@ let requestBody = {
       "recipient_type": "EMAIL",
       "email_message": "SDK payouts test txn",
       "note": "Enjoy your Payout!!",
-      "sender_batch_id": "Test_sdk_1",
+      "sender_batch_id": "Test_sdk_fail",
       "email_subject": "This is a test transaction from SDK"
     },
     "items": [{
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,65 @@ let createPayouts  = async function(){
         let response = await client.execute(request);
         console.log(`Response: ${JSON.stringify(response)}`);
         // If call returns body in response, you can get the deserialized version from the result attribute of the response.
-       console.log(`Payouts Create Response: ${JSON.stringify(response.result)}`);
+        console.log(`Payouts Create Response: ${JSON.stringify(response.result)}`);
+}
+createPayouts();
+```
+
+### Handle API Failure
+This will create a Payout with validation failure to showcase how to parse the failed response entity. Refer samples for more scenarios
+#### Code to Execute:
+```javascript
+const paypal = require('@paypal/payouts-sdk');
+  
+// Creating an environment
+let clientId = "<<PAYPAL-CLIENT-ID>>";
+let clientSecret = "<<PAYPAL-CLIENT-SECRET>>";
+let environment = new paypal.core.SandboxEnvironment(clientId, clientSecret);
+let client = new paypal.core.PayPalHttpClient(environment);
+
+let requestBody = {
+    "sender_batch_header": {
+      "recipient_type": "EMAIL",
+      "email_message": "SDK payouts test txn",
+      "note": "Enjoy your Payout!!",
+      "sender_batch_id": "Test_sdk_1",
+      "email_subject": "This is a test transaction from SDK"
+    },
+    "items": [{
+      "note": "Your 5$ Payout!",
+      "amount": {
+        "currency": "USD",
+        "value": "1.00"
+      },
+      "receiver": "payout-sdk-1@paypal.com",
+      "sender_item_id": "Test_txn_1"
+    }]
+  }
+
+// Construct a request object and set desired parameters
+// Here, PayoutsPostRequest() creates a POST request to /v1/payments/payouts
+let request = new paypal.payouts.PayoutsPostRequest();
+request.requestBody(requestBody);
+
+// Call API with your client and get a response for your call
+let createPayouts  = async function(){
+    try {
+        let response = await client.execute(request);
+        console.log(`Response: ${JSON.stringify(response)}`);
+        // If call returns body in response, you can get the deserialized version from the result attribute of the response.
+        console.log(`Payouts Create Response: ${JSON.stringify(response.result)}`);
+    catch {
+      if (e.statusCode) {
+        console.log("Status code: ", e.statusCode);
+        // Parse failure response to get the reason for failure
+        const error = JSON.parse(e.message)
+        console.log("Failure response: ", error)
+        console.log("Headers: ", e.headers)
+      } else {
+        console.log(e)
+      }
+    }
 }
 createPayouts();
 ```

--- a/lib/core/paypal_http_client.js
+++ b/lib/core/paypal_http_client.js
@@ -25,7 +25,7 @@ class PayPalHttpClient extends paypalhttp.HttpClient {
     this.addInjector(function (req) {
       req.headers['Accept-Encoding'] = 'gzip';
       req.headers["sdk_name"] = "Payouts SDK";
-      req.headers["sdk_version"] = "1.0.0";
+      req.headers["sdk_version"] = "1.1.0";
       req.headers["sdk_tech_stack"] = "NodeJS " + process.version;
       req.headers["api_integration_type"] = "PAYPALSDK";
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/payouts-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "NodeJS SDK for PayPal Payouts APIs",
   "keywords": [
     "Payouts",

--- a/samples/cancelPayoutItem.js
+++ b/samples/cancelPayoutItem.js
@@ -40,7 +40,16 @@ async function cancelPayoutItem(itemId, debug = false) {
         return response;
     }
     catch (e) {
-        console.log(e)
+        if (e.statusCode) {
+            if (debug) {
+                console.log("Status code: ", e.statusCode);
+                const error = JSON.parse(e.message)
+                console.log("Failure response: ", error)
+                console.log("Headers: ", e.headers)
+            }
+        } else {
+            console.log(e)
+        }
     }
 }
 

--- a/samples/cancelPayoutItem.js
+++ b/samples/cancelPayoutItem.js
@@ -24,7 +24,6 @@ async function cancelPayoutItem(itemId, debug = false) {
         const response = await payPalClient.client().execute(request);
         if (debug) {
             console.log("Status Code: " + response.statusCode);
-            console.log("Status: " + response.result.status);
             console.log("Payout Item ID: " + response.result.payout_item_id);
             console.log("Payout Item Status: " + response.result.transaction_status);
             console.log("Links: ");

--- a/samples/createPayout.js
+++ b/samples/createPayout.js
@@ -13,8 +13,9 @@ const payPalClient = require('./Common/payPalClient');
 /**
  * Builds the request body for creating Payouts Batch with 5 Payout Items
  */
-function buildRequestBody() {
+function buildRequestBody(includeValidationFailure) {
   let senderBatchId = "Test_sdk_" + Math.random().toString(36).substring(7);
+  let amount = includeValidationFailure ? "1.0.0" : "1.00";
   return {
     "sender_batch_header": {
       "recipient_type": "EMAIL",
@@ -27,7 +28,7 @@ function buildRequestBody() {
       "note": "Your 5$ Payout!",
       "amount": {
         "currency": "USD",
-        "value": "1.00"
+        "value": amount
       },
       "receiver": "payout-sdk-1@paypal.com",
       "sender_item_id": "Test_txn_1"
@@ -35,7 +36,7 @@ function buildRequestBody() {
       "note": "Your 5$ Payout!",
       "amount": {
         "currency": "USD",
-        "value": "1.00"
+        "value": amount
       },
       "receiver": "payout-sdk-2@paypal.com",
       "sender_item_id": "Test_txn_2"
@@ -43,7 +44,7 @@ function buildRequestBody() {
       "note": "Your 5$ Payout!",
       "amount": {
         "currency": "USD",
-        "value": "1.00"
+        "value": amount
       },
       "receiver": "payout-sdk-3@paypal.com",
       "sender_item_id": "Test_txn_3"
@@ -51,7 +52,7 @@ function buildRequestBody() {
       "note": "Your 5$ Payout!",
       "amount": {
         "currency": "USD",
-        "value": "1.00"
+        "value": amount
       },
       "receiver": "payout-sdk-4@paypal.com",
       "sender_item_id": "Test_txn_4"
@@ -59,7 +60,7 @@ function buildRequestBody() {
       "note": "Your 5$ Payout!",
       "amount": {
         "currency": "USD",
-        "value": "1.00"
+        "value": amount
       },
       "receiver": "payout-sdk-5@paypal.com",
       "sender_item_id": "Test_txn_5"
@@ -75,7 +76,7 @@ function buildRequestBody() {
 async function createPayout(debug = false) {
   try {
     const request = new payoutsSdk.payouts.PayoutsPostRequest();
-    request.requestBody(buildRequestBody());
+    request.requestBody(buildRequestBody(false));
 
     const response = await payPalClient.client().execute(request);
     if (debug) {
@@ -101,11 +102,38 @@ async function createPayout(debug = false) {
 }
 
 /**
+ * This function is used to create a Payouts Batch(POST - /v1/payments/payouts)
+ * A maximum of 15000 payout items are supported in a single batch request
+ * @param {boolean} debug - prints debug logs with details on response 
+ */
+async function createPayoutFailure(debug = false) {
+  try {
+    const request = new payoutsSdk.payouts.PayoutsPostRequest();
+    request.requestBody(buildRequestBody(true));
+
+    await payPalClient.client().execute(request);
+  }
+  catch (e) {
+    if (e.statusCode) {
+      if (debug) {
+        console.log("Status code: ", e.statusCode);
+        const error = JSON.parse(e.message)
+        console.log("Failure response: ", error)
+        console.log("Headers: ", e.headers)
+      }
+    } else {
+      console.log(e)
+    }
+  }
+}
+
+/**
  * This is the driver function which invokes the createPayout function to create
  * a Payout Batch.
  */
 if (require.main === module) {
   (async () => await createPayout(true))();
+  (async () => await createPayoutFailure(true))();
 }
 
 /**
@@ -113,4 +141,7 @@ if (require.main === module) {
  * order modules to execute the end to flow like create payout, retrieve payout, retrieve payout item
  * and cancel payout item(Optional)
  */
-module.exports = { createPayout: createPayout };
+module.exports = {
+  createPayout: createPayout,
+  createPayoutFailure: createPayoutFailure
+};

--- a/samples/createPayout.js
+++ b/samples/createPayout.js
@@ -132,8 +132,10 @@ async function createPayoutFailure(debug = false) {
  * a Payout Batch.
  */
 if (require.main === module) {
-  (async () => await createPayout(true))();
-  (async () => await createPayoutFailure(true))();
+  (async () => {
+    await createPayout(true)
+    await createPayoutFailure(true)
+  })();
 }
 
 /**

--- a/samples/createPayout.js
+++ b/samples/createPayout.js
@@ -103,7 +103,7 @@ async function createPayout(debug = false) {
 
 /**
  * This function is used to create a Payouts Batch(POST - /v1/payments/payouts)
- * A maximum of 15000 payout items are supported in a single batch request
+ * with validation failure
  * @param {boolean} debug - prints debug logs with details on response 
  */
 async function createPayoutFailure(debug = false) {

--- a/samples/createPayout.js
+++ b/samples/createPayout.js
@@ -80,7 +80,6 @@ async function createPayout(debug = false) {
     const response = await payPalClient.client().execute(request);
     if (debug) {
       console.log("Status Code: " + response.statusCode);
-      console.log("Status: " + response.result.status);
       console.log("Payout Batch ID: " + response.result.batch_header.payout_batch_id);
       console.log("Payout Batch Status: " + response.result.batch_header.batch_status);
       console.log("Links: ");

--- a/samples/createPayout.js
+++ b/samples/createPayout.js
@@ -25,7 +25,7 @@ function buildRequestBody(includeValidationFailure) {
       "email_subject": "This is a test transaction from SDK"
     },
     "items": [{
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": amount
@@ -33,7 +33,7 @@ function buildRequestBody(includeValidationFailure) {
       "receiver": "payout-sdk-1@paypal.com",
       "sender_item_id": "Test_txn_1"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": amount
@@ -41,7 +41,7 @@ function buildRequestBody(includeValidationFailure) {
       "receiver": "payout-sdk-2@paypal.com",
       "sender_item_id": "Test_txn_2"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": amount
@@ -49,7 +49,7 @@ function buildRequestBody(includeValidationFailure) {
       "receiver": "payout-sdk-3@paypal.com",
       "sender_item_id": "Test_txn_3"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": amount
@@ -57,7 +57,7 @@ function buildRequestBody(includeValidationFailure) {
       "receiver": "payout-sdk-4@paypal.com",
       "sender_item_id": "Test_txn_4"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": amount

--- a/samples/getPayout.js
+++ b/samples/getPayout.js
@@ -51,7 +51,16 @@ async function getPayout(batchId, debug = false) {
         return response;
     }
     catch (e) {
-        console.log(e)
+        if (e.statusCode) {
+            if (debug) {
+                console.log("Status code: ", e.statusCode);
+                const error = JSON.parse(e.message)
+                console.log("Failure response: ", error)
+                console.log("Headers: ", e.headers)
+            }
+        } else {
+            console.log(e)
+        }
     }
 }
 
@@ -63,6 +72,7 @@ if (require.main === module) {
     (async () => {
         let response = await createPayout();
         await getPayout(response.result.batch_header.payout_batch_id, true);
+        await getPayout("DUMMY", true);
     })();
 }
 

--- a/samples/getPayout.js
+++ b/samples/getPayout.js
@@ -33,7 +33,6 @@ async function getPayout(batchId, debug = false) {
         const response = await payPalClient.client().execute(request);
         if (debug) {
             console.log("Status Code: " + response.statusCode);
-            console.log("Status: " + response.result.status);
             console.log("Payout Batch ID: " + response.result.batch_header.payout_batch_id);
             console.log("Payout Batch Status: " + response.result.batch_header.batch_status);
             console.log("Items count: " + response.result.items.length);

--- a/samples/getPayoutItem.js
+++ b/samples/getPayoutItem.js
@@ -48,7 +48,16 @@ async function getPayoutItem(itemId, debug = false) {
         return response;
     }
     catch (e) {
-        console.log(e)
+        if (e.statusCode) {
+            if (debug) {
+                console.log("Status code: ", e.statusCode);
+                const error = JSON.parse(e.message)
+                console.log("Failure response: ", error)
+                console.log("Headers: ", e.headers)
+            }
+        } else {
+            console.log(e)
+        }
     }
 }
 
@@ -59,8 +68,9 @@ async function getPayoutItem(itemId, debug = false) {
 if (require.main === module) {
     (async () => {
         let createResponse = await createPayout();
-        let getResponse = await getPayout(createResponse.result.batch_header.payout_batch_id, true);
-        await getPayoutItem(getResponse.result.items[0].payout_item_id);
+        let getResponse = await getPayout(createResponse.result.batch_header.payout_batch_id);
+        await getPayoutItem(getResponse.result.items[0].payout_item_id, true);
+        await getPayoutItem("DUMMY", true);
     })();
 }
 

--- a/samples/getPayoutItem.js
+++ b/samples/getPayoutItem.js
@@ -32,7 +32,6 @@ async function getPayoutItem(itemId, debug = false) {
         const response = await payPalClient.client().execute(request);
         if (debug) {
             console.log("Status Code: " + response.statusCode);
-            console.log("Status: " + response.result.status);
             console.log("Payout Item ID: " + response.result.payout_item_id);
             console.log("Payout Item Status: " + response.result.transaction_status);
             console.log("Links: ");

--- a/samples/package.json
+++ b/samples/package.json
@@ -17,7 +17,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@paypal/payouts-sdk": "^1.0.0"
+    "@paypal/payouts-sdk": "^1.1.0"
   },
   "license": "MIT",
   "scripts": {

--- a/samples/runAll.js
+++ b/samples/runAll.js
@@ -1,4 +1,5 @@
 const createPayout = require('./createPayout').createPayout;
+const createPayoutFailure = require('./createPayout').createPayoutFailure;
 const getPayout = require('./getPayout').getPayout;
 const getPayoutItem = require('./getPayoutItem').getPayoutItem;
 const cancelPayoutItem = require('./cancelPayoutItem').cancelPayoutItem;
@@ -32,9 +33,13 @@ function sleep(ms) {
                     if (checkPayoutComplete.result.batch_header.batch_status === "SUCCESS") {
                         //Cancel UNCLAIMED payout item
                         console.log("Cancelling unclaimed payout item for id - " + payoutItemId);
-                        let cancelResponse = await cancelPayoutItem(payoutItemId);
+                        let cancelResponse = await cancelPayoutItem(payoutItemId, true);
                         if (getItemResponse.statusCode === 200) {
                             console.log("Unclaimed payout item cancelled successfully for id - " + payoutItemId);
+
+                            //Run cancel failure scenario
+                            console.log("Simulate failure on cancelling an already cancelled Payout item with id: " + payoutItemId);
+                            await cancelPayoutItem(payoutItemId, true);
                         } else {
                             console.error("Failed to cancel unclaimed payout item for id - " + payoutItemId);
                         }
@@ -55,6 +60,14 @@ function sleep(ms) {
     } else {
         console.error("Failed to create payout");
     }
+
+    //Execute all failure cases
+    console.log("Create a payout with validation failure");
+    await createPayoutFailure(true)
+    console.log("Retrieving an invalid payout");
+    await getPayout("DUMMY", true)
+    console.log("Retrieving an invalid payout item");
+    await getPayoutItem("DUMMY", true)
 
     process.exit();
 

--- a/spec/payouts/payoutsPostTest.js
+++ b/spec/payouts/payoutsPostTest.js
@@ -16,7 +16,7 @@ function buildRequestBody() {
       "email_subject": "This is a test transaction from SDK"
     },
     "items": [{
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -24,7 +24,7 @@ function buildRequestBody() {
       "receiver": "payout-sdk-1@paypal.com",
       "sender_item_id": "Test_txn_1"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -32,7 +32,7 @@ function buildRequestBody() {
       "receiver": "payout-sdk-2@paypal.com",
       "sender_item_id": "Test_txn_2"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -40,7 +40,7 @@ function buildRequestBody() {
       "receiver": "payout-sdk-3@paypal.com",
       "sender_item_id": "Test_txn_3"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"
@@ -48,7 +48,7 @@ function buildRequestBody() {
       "receiver": "payout-sdk-4@paypal.com",
       "sender_item_id": "Test_txn_4"
     }, {
-      "note": "Your 5$ Payout!",
+      "note": "Your 1$ Payout!",
       "amount": {
         "currency": "USD",
         "value": "1.00"


### PR DESCRIPTION
This PR covers the following

1. Prepare to release https://github.com/paypal/Payouts-NodeJS-SDK/pull/4 which addresses restricting npm package to have necessary files
2. Add samples on handling API failures and how to parse error definition from it
3. Update readme with API failure sample
4. Fix verbiage in payload representation from `5$` to `1$` in README, samples, tests